### PR TITLE
Build various docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+./docker
+./tests

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,47 @@
+FROM python:3.5-alpine
+
+ARG ARTHUR_VERSION
+
+ENV \
+  ARTHUR_HOST="0.0.0.0"\
+  ARTHUR_PORT="8080" \
+  ARTHUR_DATABASE="redis://localhost/8" \
+  ARTHUR_LOGS_DIR="/arthur/logs"
+
+EXPOSE 8080
+
+LABEL \
+  maintainer="Chaoss" \
+  description="Arthur is a distributed job queue platform that schedules and executes Perceval" \
+  project="https://github.com/chaoss/grimoirelab-kingarthur" \
+  version="$ARTHUR_VERSION"
+
+RUN \
+  addgroup -g 1000 arthur && \
+  adduser -G arthur -D -u 1000 -h /arthur arthur
+
+RUN \
+  apk add --no-cache tini git gcc musl-dev
+
+COPY . /arthur
+
+WORKDIR /arthur
+
+RUN \
+  mkdir /arthur/logs && \
+  chown arthur:arthur -R /arthur && \
+  pip3.5 install --user -r requirements.txt
+
+USER arthur
+
+RUN \
+  python3 setup.py install --user
+
+# /tmp is used by arthur to store temp files like git repository
+VOLUME ["/tmp", "/arthur/logs"]
+
+ENTRYPOINT [\
+  "/sbin/tini","--",\
+  "/bin/sh", "-c", \
+  "/usr/local/bin/python3 bin/arthurd --no-daemon --host $ARTHUR_HOST --port $ARTHUR_PORT --database $ARTHUR_DATABASE --log-path $ARTHUR_LOGS_DIR --sync"\
+  ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,27 +1,56 @@
-FROM python:3.5-alpine
+# Copyright (C) 2018 Bitergia
+# GPLv3 License
+
+FROM debian:stretch-slim
 
 ARG ARTHUR_VERSION
+
+LABEL \
+  maintainer="Alvaro del Castillo <acs@bitergia.com>" \
+  description="Arthur is a distributed job queue platform that schedules and executes Perceval" \
+  project="https://github.com/chaoss/grimoirelab-kingarthur" \
+  version="$ARTHUR_VERSION"
+
+EXPOSE 8080
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV DEPLOY_USER grimoirelab
+ENV DEPLOY_USER_DIR /home/${DEPLOY_USER}
+
+RUN \
+  groupadd -g 1000 arthur && \
+  useradd -m -d /arthur -g 1000 -u 1000 -s /bin/sh arthur
+
+# install dependencies
+RUN apt-get update && \
+    apt-get -y install --no-install-recommends \
+        bash locales \
+        git gcc \
+        python3 \
+        python3-pip \
+        python3-venv \
+        python3-dev \
+        unzip curl wget sudo ssh vim \
+        && \
+    apt-get clean && \
+    find /var/lib/apt/lists -type f -delete
+
+RUN echo "${DEPLOY_USER} ALL=NOPASSWD: ALL" >> /etc/sudoers
+
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    echo 'LANG="en_US.UTF-8"'>/etc/default/locale && \
+    dpkg-reconfigure --frontend=noninteractive locales && \
+    update-locale LANG=en_US.UTF-8
 
 ENV \
   ARTHUR_HOST="0.0.0.0"\
   ARTHUR_PORT="8080" \
   ARTHUR_DATABASE="redis://localhost/8" \
-  ARTHUR_LOGS_DIR="/arthur/logs"
-
-EXPOSE 8080
-
-LABEL \
-  maintainer="Chaoss" \
-  description="Arthur is a distributed job queue platform that schedules and executes Perceval" \
-  project="https://github.com/chaoss/grimoirelab-kingarthur" \
-  version="$ARTHUR_VERSION"
-
-RUN \
-  addgroup -g 1000 arthur && \
-  adduser -G arthur -D -u 1000 -h /arthur arthur
-
-RUN \
-  apk add --no-cache tini git gcc musl-dev
+  ARTHUR_LOGS_DIR="/arthur/logs" \
+  LANG="en_US.UTF-8" \
+  LANGUAGE="en_US:en" \
+  LC_ALL="en_US.UTF-8" \
+  LANG="C.UTF-8"
 
 COPY --chown=arthur . /arthur
 
@@ -31,15 +60,15 @@ USER arthur
 
 RUN \
   mkdir /arthur/logs && \
-  pip3.5 install --no-cache-dir --upgrade pip && \
-  pip3.5 install --no-cache-dir --user -r requirements.txt && \
+  pip3 install setuptools && \
+  pip3 install --no-cache-dir --upgrade pip && \
+  pip3 install --no-cache-dir --user -r requirements.txt && \
   python3 setup.py install --user
 
 # /tmp is used by arthur to store temp files like git repository
 VOLUME ["/tmp", "/arthur/logs"]
 
 ENTRYPOINT [\
-  "/sbin/tini","--",\
   "/bin/sh", "-c", \
-  "/usr/local/bin/python3 bin/arthurd --no-daemon --host ${ARTHUR_HOST} --port ${ARTHUR_PORT} --database ${ARTHUR_DATABASE} --log-path ${ARTHUR_LOGS_DIR} --sync"\
+  "python3 bin/arthurd --no-daemon --host ${ARTHUR_HOST} --port ${ARTHUR_PORT} --database ${ARTHUR_DATABASE} --log-path ${ARTHUR_LOGS_DIR} --sync"\
   ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,18 +23,16 @@ RUN \
 RUN \
   apk add --no-cache tini git gcc musl-dev
 
-COPY . /arthur
+COPY --chown=arthur . /arthur
 
 WORKDIR /arthur
-
-RUN \
-  mkdir /arthur/logs && \
-  chown arthur:arthur -R /arthur && \
-  pip3.5 install --user -r requirements.txt
 
 USER arthur
 
 RUN \
+  mkdir /arthur/logs && \
+  pip3.5 install --no-cache-dir --upgrade pip && \
+  pip3.5 install --no-cache-dir --user -r requirements.txt && \
   python3 setup.py install --user
 
 # /tmp is used by arthur to store temp files like git repository
@@ -43,5 +41,5 @@ VOLUME ["/tmp", "/arthur/logs"]
 ENTRYPOINT [\
   "/sbin/tini","--",\
   "/bin/sh", "-c", \
-  "/usr/local/bin/python3 bin/arthurd --no-daemon --host $ARTHUR_HOST --port $ARTHUR_PORT --database $ARTHUR_DATABASE --log-path $ARTHUR_LOGS_DIR --sync"\
+  "/usr/local/bin/python3 bin/arthurd --no-daemon --host ${ARTHUR_HOST} --port ${ARTHUR_PORT} --database ${ARTHUR_DATABASE} --log-path ${ARTHUR_LOGS_DIR} --sync"\
   ]

--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -1,9 +1,9 @@
 ARG ARTHUR_VERSION
 
-FROM grimoirelab/arthur:$ARTHUR_VERSION
+FROM olblak/arthur:$ARTHUR_VERSION
 
 ENTRYPOINT [\
   "/sbin/tini","--",\
   "/bin/sh", "-c", \
-  "exec /usr/local/bin/python3 bin/arthurd --no-daemon --host ${ARTHUR_HOST} --port ${ARTHUR_PORT} --database ${ARTHUR_DATABASE} --log-path ${ARTHUR_LOGS_DIR} --no-cache"\
+  "exec /usr/local/bin/python3 bin/arthurd --no-daemon --host ${ARTHUR_HOST} --port ${ARTHUR_PORT} --database ${ARTHUR_DATABASE} --log-path ${ARTHUR_LOGS_DIR}"\
   ]

--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -5,5 +5,5 @@ FROM olblak/arthur:$ARTHUR_VERSION
 ENTRYPOINT [\
   "/sbin/tini","--",\
   "/bin/sh", "-c", \
-  "exec /usr/local/bin/python3 bin/arthurd --no-daemon --host ${ARTHUR_HOST} --port ${ARTHUR_PORT} --database ${ARTHUR_DATABASE} --log-path ${ARTHUR_LOGS_DIR}"\
+  "exec /usr/local/bin/python3 bin/arthurd --no-daemon --host ${ARTHUR_HOST} --port ${ARTHUR_PORT} --database ${ARTHUR_DATABASE} --log-path ${ARTHUR_LOGS_DIR} --no-archive"\
   ]

--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -5,5 +5,5 @@ FROM grimoirelab/arthur:$ARTHUR_VERSION
 ENTRYPOINT [\
   "/sbin/tini","--",\
   "/bin/sh", "-c", \
-  "exec /usr/local/bin/python3 bin/arthurd --no-daemon --host $ARTHUR_HOST --port $ARTHUR_PORT --database $ARTHUR_DATABASE --log-path $ARTHUR_LOGS_DIR --no-cache"\
+  "exec /usr/local/bin/python3 bin/arthurd --no-daemon --host ${ARTHUR_HOST} --port ${ARTHUR_PORT} --database ${ARTHUR_DATABASE} --log-path ${ARTHUR_LOGS_DIR} --no-cache"\
   ]

--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -1,0 +1,9 @@
+ARG ARTHUR_VERSION
+
+FROM grimoirelab/arthur:$ARTHUR_VERSION
+
+ENTRYPOINT [\
+  "/sbin/tini","--",\
+  "/bin/sh", "-c", \
+  "exec /usr/local/bin/python3 bin/arthurd --no-daemon --host $ARTHUR_HOST --port $ARTHUR_PORT --database $ARTHUR_DATABASE --log-path $ARTHUR_LOGS_DIR --no-cache"\
+  ]

--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -1,9 +1,8 @@
 ARG ARTHUR_VERSION
 
-FROM olblak/arthur:$ARTHUR_VERSION
+FROM grimoirelab/arthur:$ARTHUR_VERSION
 
 ENTRYPOINT [\
-  "/sbin/tini","--",\
   "/bin/sh", "-c", \
-  "exec /usr/local/bin/python3 bin/arthurd --no-daemon --host ${ARTHUR_HOST} --port ${ARTHUR_PORT} --database ${ARTHUR_DATABASE} --log-path ${ARTHUR_LOGS_DIR} --no-archive"\
+  "python3 bin/arthurd --no-daemon --host ${ARTHUR_HOST} --port ${ARTHUR_PORT} --database ${ARTHUR_DATABASE} --log-path ${ARTHUR_LOGS_DIR} --no-archive"\
   ]

--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -3,7 +3,6 @@ ARG ARTHUR_VERSION
 FROM grimoirelab/arthur:$ARTHUR_VERSION
 
 ENTRYPOINT [\
-  "/sbin/tini","--",\
   "/bin/sh", "-c", \
-  "exec /usr/local/bin/python3 bin/arthurw -d ${ARTHUR_DATABASE} ${ARTHUR_WORKER_QUEUE}"\
+  "exec python3 bin/arthurw -d ${ARTHUR_DATABASE} ${ARTHUR_WORKER_QUEUE}"\
   ]

--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -5,5 +5,5 @@ FROM grimoirelab/arthur:$ARTHUR_VERSION
 ENTRYPOINT [\
   "/sbin/tini","--",\
   "/bin/sh", "-c", \
-  "exec /usr/local/bin/python3 bin/arthurw -d $ARTHUR_DATABASE $ARTHUR_WORKER_QUEUE"\
+  "exec /usr/local/bin/python3 bin/arthurw -d ${ARTHUR_DATABASE} ${ARTHUR_WORKER_QUEUE}"\
   ]

--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -5,5 +5,5 @@ FROM grimoirelab/arthur:$ARTHUR_VERSION
 ENTRYPOINT [\
   "/sbin/tini","--",\
   "/bin/sh", "-c", \
-  "exec /usr/local/bin/python3 bin/arthurw -d $ARTHUR_DATABASE"\
+  "exec /usr/local/bin/python3 bin/arthurw -d $ARTHUR_DATABASE $ARTHUR_WORKER_QUEUE"\
   ]

--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -1,0 +1,9 @@
+ARG ARTHUR_VERSION
+
+FROM grimoirelab/arthur:$ARTHUR_VERSION
+
+ENTRYPOINT [\
+  "/sbin/tini","--",\
+  "/bin/sh", "-c", \
+  "exec /usr/local/bin/python3 bin/arthurw -d $ARTHUR_DATABASE"\
+  ]

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,25 @@
+VERSION= $(shell grep '_version_' ../arthur/_version.py  | awk -F '"' '{print $$2}') 
+IMAGE='grimoirelab/arthur'
+
+build: build_standalone build_server build_worker
+
+publish: publish_standalone publish_server publish_worker
+
+build_standalone:
+	@docker build -t $(IMAGE):$(VERSION) --build-arg ARTHUR_VERSION=$(VERSION) -f Dockerfile ..
+
+build_server:
+	@docker build -t $(IMAGE):server-$(VERSION) --build-arg ARTHUR_VERSION=$(VERSION) -f Dockerfile.server ..
+
+build_worker:
+	@docker build -t $(IMAGE):worker-$(VERSION) --build-arg ARTHUR_VERSION=$(VERSION) -f Dockerfile.worker .
+
+publish_standalone:
+	@docker push $(IMAGE):$(VERSION)
+
+publish_server:
+	@docker push $(IMAGE):server-$(VERSION)
+
+publish_worker:
+	@docker push $(IMAGE):worker-$(VERSION)
+

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,77 @@
+# README
+This project provide three different docker images.
+* Arthur
+* Arthur Server
+* Arthur Worker
+
+## ARTHUR
+This docker image run a standalone Arthur service (server and worker).
+It can be configured with environment variables.
+
+### ENVIRONMENT
+#### ARTHUR_HOST
+Define Arthur listening url, default set to `0.0.0.0`
+
+#### ARTHUR_PORT
+Define Arthur server listening port, default set to `8080`
+
+#### ARTHUR_DATABASE
+Define Redis database url used by Arthur, default set to `redis://localhost/8`
+
+#### ARTHUR_LOGS_DIR
+Define Arthur logs directory, default set to `/arthur/logs`
+
+### EXAMPLE
+```
+docker run -i -t --rm -e 'ARTHUR_DATABASE=redis://redis' grimoirelab/arthur:0.1.3
+```
+
+## ARTHUR SERVER
+This docker image run an Arthur server.  
+It brings more flexibility when used with Arthur workers.   
+It can be configured with environment variables.
+
+### ENVIRONMENT
+#### ARTHUR_HOST
+Define Arthur listening url, default set to `0.0.0.0`
+
+#### ARTHUR_PORT
+Define Arthur server listening port, default set to `8080`
+
+#### ARTHUR_DATABASE
+Define Redis database url used by Arthur, default set to `redis://localhost/8`
+
+#### ARTHUR_LOGS_DIR
+Define Arthur logs directory, default set to `/arthur/logs`
+
+### EXAMPLE
+```
+docker run -i -t --rm -e 'ARTHUR_DATABASE=redis://redis' grimoirelab/arthur:server-0.1.3
+```
+
+## ARTHUR WORKER
+This docker image run an Arthur worker.
+This image must be used in an association with an arthur server
+
+### CONFIGURATION
+#### ARTHUR_DATABASE
+Define the Redis database url used by Arthur, default set to ```redis://localhost/8```
+
+#### ARTHUR_WORKER_QUEUE
+Define the listened database queue, default set to 'create, update'.  
+Only accept value `create` or `update`
+
+### EXAMPLE
+```
+docker run -i -t --rm -e 'ARTHUR_DATABASE=redis://redis' -e "ARTHUR_WORKER_QUEUE=update" grimoirelab/arthur:worker-0.1.3
+```
+
+## DOCKER
+### BUILD
+In order to build new docker images, just run `make build` to create those images
+with tags based on the version defined in file `../arthur/_version.py`.
+
+### PUBLISH
+In order to publish docker images on the registry, just run `make publish` to push
+docker images.
+The variable 'IMAGE', in the Makefile, defines where the image will be publish.


### PR DESCRIPTION
Hi,
I am proposing this PR to create three different docker images which I think is better than #18 for following reasons.

* Docker image is smaller (232MB)
* Each docker image does only one thing
    Run an arthur server,  arthur worker,  arthur in sync mode
* Use version defined in arthur/_version.py, to assign a docker image tag
* Provide a Makefile to build and publish the docker image
``make build publish ``

Generate following images

- grimoirelab/arthur:server-0.1.3
- grimoirelab/arthur:0.1.3
- grimoirelab/arthur :worker-0.1.3