### PR TITLE
Update documentation with information about arthurd configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,35 @@ optional arguments:
   --no-daemon           do not run arthur in daemon mode
 ```
 
+#### arthurd configuration file
+
+To run `arthurd` using a configuration file:
+
+```
+$ arthurd [-c <file>]
+```
+
+Where `<file>` is the path to an `ini` file which uses the same parameters as in command line, but replacing underscores by hyphens. This configuration file has the following structure:
+
+```
+[arthur]
+archive_path=/tmp/.arthur/archive
+debug=True
+log_path=/tmp/logs/arthurd
+no_archive=True
+sync_mode=True
+
+[connection]
+host=127.0.0.1
+port=8080
+
+[elasticsearch]
+es_index=http://localhost:9200/items
+
+[redis]
+database=redis://localhost/8
+```
+
 ### arthurw
 ```
 usage: arthurw [-g] [-d <database>] [--burst] [<queue1>...<queueN>] | --help


### PR DESCRIPTION
This new section includes how to run `arthurd` using a configuration file and an example of its structure.