### PR TITLE
[jobs] Fix 'from_date' and 'offset' reset error

### DIFF
--- a/arthur/jobs.py
+++ b/arthur/jobs.py
@@ -24,14 +24,15 @@
 import functools
 import logging
 
-import rq
 import pickle
+import rq
 
 import perceval
 import perceval.backends
 import perceval.archive
 
-from grimoirelab.toolkit.datetime import unixtime_to_datetime
+from grimoirelab.toolkit.datetime import (datetime_to_utc,
+                                          unixtime_to_datetime)
 
 from ._version import __version__
 from .errors import NotFoundError
@@ -167,8 +168,14 @@ class PercevalJob:
             self.initialize_archive_manager(archive_args['archive_path'])
 
         if not resume:
+            max_date = backend_args.get('from_date', None)
+            offset = backend_args.get('offset', None)
+
+            if max_date:
+                max_date = datetime_to_utc(max_date).timestamp()
+
             self._result = JobResult(self.job_id, self.task_id, self.backend, self.category,
-                                     None, None, 0, offset=None,
+                                     None, max_date, 0, offset=offset,
                                      nresumed=0)
         else:
             if self.result.max_date:

--- a/arthur/scheduler.py
+++ b/arthur/scheduler.py
@@ -336,12 +336,11 @@ class Scheduler:
 
         job_args = self._build_job_arguments(task)
 
-        if result.nitems > 0:
-            from_date = unixtime_to_datetime(result.max_date)
-            job_args['backend_args']['from_date'] = from_date
+        from_date = unixtime_to_datetime(result.max_date)
+        job_args['backend_args']['from_date'] = from_date
 
-            if result.offset:
-                job_args['backend_args']['offset'] = result.offset
+        if result.offset:
+            job_args['backend_args']['offset'] = result.offset
 
         delay = task.sched_args['delay']
 

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -673,7 +673,7 @@ class TestExecuteJob(TestBaseRQ):
         self.assertEqual(result.backend, 'git')
         self.assertEqual(result.category, 'commit')
         self.assertEqual(result.last_uuid, None)
-        self.assertEqual(result.max_date, None)
+        self.assertEqual(result.max_date, 1577840461.0)
         self.assertEqual(result.nitems, 0)
         self.assertEqual(result.offset, None)
         self.assertEqual(result.nresumed, 0)


### PR DESCRIPTION
So far, when a job runs in the 'update' queue and no new items are fetched, either 'from_date' or 'offset' values are reset to the starting values defined for the parent task (in backend_args).

This is an error because jobs in 'update' must start from the point where the previous job ended.

Fixes #27