### PR TITLE
Remove job sched args from execute_perceval_job

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ $ cat tasks.json
             },
             "scheduler": {
                 "delay": 60,
-                "max_retries_job": 5
+                "max_retries": 5
             }
         }
     ]
@@ -209,7 +209,7 @@ $ curl http://127.0.0.1:8080/tasks
             "created_on": 1480531707.810326,
             "task_id": "arthur.git",
             "scheduler": {
-                "max_retries_job": 3,
+                "max_retries": 3,
                 "delay": 10
             }
         }

--- a/arthur/arthur.py
+++ b/arthur/arthur.py
@@ -158,21 +158,21 @@ class Arthur:
         """Parse the schedule arguments of a task"""
 
         if not sched_args:
-            return {}
+            sched_args = {}
 
         if 'delay' not in sched_args:
             sched_args['delay'] = WAIT_FOR_QUEUING
 
-        if 'max_retries_job' not in sched_args:
-            sched_args['max_retries_job'] = MAX_JOB_RETRIES
+        if 'max_retries' not in sched_args:
+            sched_args['max_retries'] = MAX_JOB_RETRIES
 
         for arg in sched_args.keys():
             if arg == 'delay':
                 if type(sched_args['delay']) is not int:
                     raise ValueError("sched_args.delay not int")
-            elif arg == 'max_retries_job':
-                if type(sched_args['max_retries_job']) is not int:
-                    raise ValueError("sched_args.max_retries_job not int")
+            elif arg == 'max_retries':
+                if type(sched_args['max_retries']) is not int:
+                    raise ValueError("sched_args.max_retries not int")
             else:
                 raise ValueError("%s not accepted in schedule_args" % arg)
 

--- a/arthur/scheduler.py
+++ b/arthur/scheduler.py
@@ -377,6 +377,6 @@ class Scheduler:
         job_args['archive_args'] = copy.deepcopy(task.archive_args)
 
         # Scheduler parameters
-        job_args['sched_args'] = copy.deepcopy(task.sched_args)
+        job_args['max_retries'] = task.sched_args['max_retries']
 
         return job_args

--- a/tests/test_arthur.py
+++ b/tests/test_arthur.py
@@ -79,7 +79,7 @@ class TestArthur(unittest.TestCase):
         self.assertEqual(t.backend, backend)
         self.assertDictEqual(t.backend_args, backend_params)
         self.assertDictEqual(t.archive_args, {})
-        self.assertDictEqual(t.sched_args, {})
+        self.assertDictEqual(t.sched_args, {'max_retries': 3, 'delay': 10})
 
         self.assertEqual(initial_tasks, 0)
         self.assertEqual(after_tasks, 1)
@@ -105,7 +105,7 @@ class TestArthur(unittest.TestCase):
         self.assertEqual(t.backend, backend)
         self.assertDictEqual(t.backend_args, backend_params)
         self.assertDictEqual(t.archive_args, archive_params)
-        self.assertDictEqual(t.sched_args, {})
+        self.assertDictEqual(t.sched_args, {'max_retries': 3, 'delay': 10})
 
         self.assertEqual(initial_tasks, 0)
         self.assertEqual(after_tasks, 1)
@@ -213,7 +213,7 @@ class TestArthur(unittest.TestCase):
         archive_params = {'fetch_from_archive': True,
                           'archived_after': '2100-01-01',
                           'archive_path': './acme-plan'}
-        sched_params = {"delay": 10, "max_retries_job": 10}
+        sched_params = {"delay": 10, "max_retries": 10}
 
         app = Arthur(self.conn, base_archive_path=self.tmp_path, async_mode=False)
 
@@ -240,7 +240,7 @@ class TestArthur(unittest.TestCase):
         backend = "backend"
         category = None
         backend_params = {"a": "a", "b": "b"}
-        sched_params = {"unknown": 1, "delay": 10, "max_retries_job": 10}
+        sched_params = {"unknown": 1, "delay": 10, "max_retries": 10}
 
         app = Arthur(self.conn, async_mode=False)
 
@@ -256,7 +256,7 @@ class TestArthur(unittest.TestCase):
         backend = "backend"
         category = None
         backend_params = {"a": "a", "b": "b"}
-        sched_params = {"delay": "1", "max_retries_job": 10}
+        sched_params = {"delay": "1", "max_retries": 10}
 
         app = Arthur(self.conn, async_mode=False)
 
@@ -265,21 +265,21 @@ class TestArthur(unittest.TestCase):
 
         self.assertEqual(ex.exception.args[0], "sched_args.delay not int")
 
-    def test_task_wrong_max_retries_job(self):
-        """Check whether an exception is thrown when max_retries_job parameter is not properly set"""
+    def test_task_wrong_max_retries(self):
+        """Check whether an exception is thrown when max_retries parameter is not properly set"""
 
         task_id = "arthur.task"
         backend = "backend"
         category = None
         backend_params = {"a": "a", "b": "b"}
-        sched_params = {"delay": 1, "max_retries_job": "c"}
+        sched_params = {"delay": 1, "max_retries": "c"}
 
         app = Arthur(self.conn, async_mode=False)
 
         with self.assertRaises(ValueError) as ex:
             app.add_task(task_id, backend, category, backend_params, sched_args=sched_params)
 
-        self.assertEqual(ex.exception.args[0], "sched_args.max_retries_job not int")
+        self.assertEqual(ex.exception.args[0], "sched_args.max_retries not int")
 
     def test_add_duplicated_task(self):
         """Check whether an exception is thrown when a duplicated task is added"""

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -46,7 +46,7 @@ class TestScheduler(TestBaseRQ):
         archive_args = {}
         sched_args = {
             'delay': 0,
-            'max_retries_job': 0
+            'max_retries': 0
         }
 
         registry = TaskRegistry()


### PR DESCRIPTION
This function only needs `max_retries` parameter but it was getting the full set of arguments.