### PR TITLE
[jobs] Add category to backend arguments

### DIFF
--- a/arthur/jobs.py
+++ b/arthur/jobs.py
@@ -233,10 +233,12 @@ class PercevalJob:
             parameters is not found
         """
         if not archive_args or not archive_args['fetch_from_archive']:
-            return perceval.backend.fetch(self._bklass, backend_args, manager=self.archive_manager)
+            return perceval.backend.fetch(self._bklass, backend_args, self.category,
+                                          manager=self.archive_manager)
         else:
-            return perceval.backend.fetch_from_archive(self._bklass, backend_args, self.archive_manager,
-                                                       self.category, archive_args['archived_after'])
+            return perceval.backend.fetch_from_archive(self._bklass, backend_args,
+                                                       self.archive_manager, self.category,
+                                                       archive_args['archived_after'])
 
 
 def execute_perceval_job(backend, backend_args, qitems, task_id, category,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -80,7 +80,7 @@ class TestArthurServer(unittest.TestCase):
                             "uri": "https://github.com/grimoirelab/arthur.git",
                             "from_date": "2015-03-01"
                         },
-                        "category": "acme",
+                        "category": "commit",
                         "archive": {},
                         "scheduler": {
                             "delay": 10
@@ -114,7 +114,7 @@ class TestArthurServer(unittest.TestCase):
                             "uri": "https://github.com/grimoirelab/arthur.git",
                             "from_date": "2015-03-01"
                         },
-                        "category": "acme",
+                        "category": "commit",
                         "archive": {},
                         "scheduler": {
                             "delay": 10
@@ -127,7 +127,7 @@ class TestArthurServer(unittest.TestCase):
                             "url": "https://bugzilla.redhat.com/",
                             "from_date": "2016-09-19"
                         },
-                        "category": "acme",
+                        "category": "issue",
                         "archive": {
                             'archive_path': '/tmp/archive',
                             'fetch_from_archive': False
@@ -165,7 +165,7 @@ class TestArthurServer(unittest.TestCase):
                             "uri": "https://github.com/grimoirelab/arthur.git",
                             "from_date": "2015-03-01"
                         },
-                        "category": "acme",
+                        "category": "commit",
                         "archive": {},
                         "scheduler": {
                             "delay": 10
@@ -178,7 +178,7 @@ class TestArthurServer(unittest.TestCase):
                             "url": "https://bugzilla.redhat.com/",
                             "from_date": "2016-09-19"
                         },
-                        "category": "acme",
+                        "category": "issue",
                         "archive": {
                             'archive_path': '/tmp/archive',
                             'fetch_from_archive': True,


### PR DESCRIPTION
This code includes the category within the backend arguments before calling Perceval. Thus, it allows to deal with backends with multiple categories.