### PR TITLE
[arthur] Add validation for tasks

### DIFF
--- a/arthur/arthur.py
+++ b/arthur/arthur.py
@@ -73,6 +73,7 @@ class Arthur:
         try:
             archiving_cfg = self.__parse_archive_args(archive_args)
             scheduling_cfg = self.__parse_schedule_args(sched_args)
+            self.__validate_args(task_id, backend, category, backend_args)
         except ValueError as e:
             raise e
 
@@ -113,6 +114,26 @@ class Arthur:
         for item in items:
             item = pickle.loads(item)
             yield item
+
+    @staticmethod
+    def __validate_args(task_id, backend, category, backend_args):
+        """Check that the task arguments received are valid"""
+
+        if not task_id or task_id.strip() == "":
+            msg = "Missing task_id for task"
+            raise ValueError(msg)
+
+        if not backend or backend.strip() == "":
+            msg = "Missing backend for task '%s'" % task_id
+            raise ValueError(msg)
+
+        if backend_args and not isinstance(backend_args, dict):
+            msg = "Backend_args is not a dict, task '%s'" % task_id
+            raise ValueError(msg)
+
+        if not category or category.strip() == "":
+            msg = "Missing category for task '%s'" % task_id
+            raise ValueError(msg)
 
     def __parse_archive_args(self, archive_args):
         """Parse the archive arguments of a task"""

--- a/tests/test_arthur.py
+++ b/tests/test_arthur.py
@@ -71,7 +71,7 @@ class TestArthur(unittest.TestCase):
 
         task_id = "arthur.task"
         backend = "backend"
-        category = None
+        category = "mock_category"
         backend_params = {"a": "a", "b": "b"}
 
         app = Arthur(self.conn, async_mode=False)
@@ -96,7 +96,7 @@ class TestArthur(unittest.TestCase):
 
         task_id = "arthur.task"
         backend = "backend"
-        category = None
+        category = "mock_category"
         backend_params = {"a": "a", "b": "b"}
         archive_params = None
 
@@ -139,7 +139,7 @@ class TestArthur(unittest.TestCase):
 
         task_id = "arthur.task"
         backend = "backend"
-        category = None
+        category = "mock_category"
         backend_params = {"a": "a", "b": "b"}
         archive_params = {
             'fetch_from_archive': True,
@@ -322,6 +322,70 @@ class TestArthur(unittest.TestCase):
 
         with self.assertRaises(AlreadyExistsError):
             app.add_task("arthur.task", "backend", "category", {"a": "a", "b": "b"})
+
+    def test_add_task_no_task_id(self):
+        """Check whether an exception is thrown when the task id is missing"""
+
+        task_id = None
+        backend = "backend"
+        category = "mock_category"
+        backend_params = {"a": "a", "b": "b"}
+
+        app = Arthur(self.conn, async_mode=False)
+
+        with self.assertRaises(ValueError):
+            app.add_task(task_id, backend, category, backend_params)
+
+        task_id = "     "
+        with self.assertRaises(ValueError):
+            app.add_task(task_id, backend, category, backend_params)
+
+    def test_add_task_no_backend(self):
+        """Check whether an exception is thrown when the backend is missing"""
+
+        task_id = "task"
+        backend = None
+        category = "mock_category"
+        backend_params = {"a": "a", "b": "b"}
+
+        app = Arthur(self.conn, async_mode=False)
+
+        with self.assertRaises(ValueError):
+            app.add_task(task_id, backend, category, backend_params)
+
+        backend = "     "
+        with self.assertRaises(ValueError):
+            app.add_task(task_id, backend, category, backend_params)
+
+    def test_add_task_no_category(self):
+        """Check whether an exception is thrown when the backend category is missing"""
+
+        task_id = "task"
+        backend = "backend"
+        category = None
+        backend_params = {"a": "a", "b": "b"}
+
+        app = Arthur(self.conn, async_mode=False)
+
+        with self.assertRaises(ValueError):
+            app.add_task(task_id, backend, category, backend_params)
+
+        category = "     "
+        with self.assertRaises(ValueError):
+            app.add_task(task_id, backend, category, backend_params)
+
+    def test_add_task_invalid_format_backend_args(self):
+        """Check whether an exception is thrown when the backend args is not a dict"""
+
+        task_id = "task"
+        backend = "backend"
+        category = "mock_item"
+        backend_params = "wrong_params"
+
+        app = Arthur(self.conn, async_mode=False)
+
+        with self.assertRaises(ValueError):
+            app.add_task(task_id, backend, category, backend_params)
 
     def test_remove_task(self):
         """Check whether the removal of tasks is properly handled"""

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -228,7 +228,7 @@ class TestTaskRegistry(unittest.TestCase):
         with self.assertRaises(NotFoundError):
             registry.remove('mytask')
 
-        registry.add('task', 'mock_backend', None, '/tmp/example')
+        registry.add('task', 'mock_backend', "mock_category", {})
 
         with self.assertRaises(NotFoundError):
             registry.remove('mytask')


### PR DESCRIPTION
This code enables validation of the tasks sent to the Arthur server. It checks that `task_id`, `backend`, `category` are not null or empty as well as it makes sure that the `backend_args` is a dict (if defined).