### PR TITLE
[jobs] Add __repr__ method

### DIFF
--- a/arthur/jobs.py
+++ b/arthur/jobs.py
@@ -92,6 +92,10 @@ class JobResult:
         self.offset = offset
         self.nresumed = nresumed
 
+    def __repr__(self):
+        return "job id: %s, task id: %s, backend: %s, category: %s, nitems: %s" % \
+               (self.job_id, self.task_id, self.backend, self.category, self.nitems)
+
 
 class PercevalJob:
     """Class for wrapping Perceval jobs.

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -254,6 +254,8 @@ class TestJobResult(unittest.TestCase):
 
         self.assertEqual(result.offset, 128)
         self.assertEqual(result.nresumed, 10)
+        self.assertEqual(str(result), 'job id: arthur-job-1234567890, task id: mytask, '
+                                      'backend: mock_backend, category: category, nitems: 58')
 
 
 class TestPercevalJob(TestBaseRQ):


### PR DESCRIPTION
This code defines the `__repr__` method for the JobResult class in order to improve the log messages generated by the redis class rq.worker.