### PR TITLE
Refactor events listener to decouple it from job scheduler

### DIFF
--- a/arthur/events.py
+++ b/arthur/events.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2019 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#
+
+import logging
+import pickle
+import traceback
+import threading
+
+import rq
+
+from .common import CH_PUBSUB
+
+
+logger = logging.getLogger(__name__)
+
+
+class JobEventsListener(threading.Thread):
+    """Listen jobs events.
+
+    This class listens in a separate thread for those events produced
+    by the running jobs. A set of handlers can be given to process
+    those events.
+
+    :param conn: connection to the Redis database
+    :param events_channel: name of the events channel where jobs write events
+    :param result_handler: callable object to handle successful jobs
+    :param result_handler_err: callable object to handle failed jobs
+    """
+    def __init__(self, conn, events_channel=CH_PUBSUB,
+                 result_handler=None, result_handler_err=None):
+        super().__init__()
+        self.conn = conn
+        self.events_channel = events_channel
+        self.result_handler = result_handler
+        self.result_handler_err = result_handler_err
+
+    def run(self):
+        """Start a thread to listen for jobs events."""
+
+        try:
+            self.listen()
+        except Exception as e:
+            logger.critical("JobEventsListener instance crashed. Error: %s", str(e))
+            logger.critical(traceback.format_exc())
+
+    def listen(self):
+        """Listen for completed jobs and reschedule successful ones."""
+
+        pubsub = self.conn.pubsub()
+        pubsub.subscribe(self.events_channel)
+
+        logger.debug("Listening on channel %s", self.events_channel)
+
+        for msg in pubsub.listen():
+            logger.debug("New message received of type %s", str(msg['type']))
+
+            if msg['type'] != 'message':
+                logger.debug("Ignoring job message")
+                continue
+
+            data = pickle.loads(msg['data'])
+
+            self._dispatch_event(data)
+
+    def _dispatch_event(self, data):
+        """Dispatches the job event to the right handler."""
+
+        job_id = data['job_id']
+        status = data['status']
+
+        if status == 'finished':
+            logging.debug("Job #%s completed", job_id)
+            handler = self.result_handler
+        elif status == 'failed':
+            logging.debug("Job #%s failed", job_id)
+            handler = self.result_handler_err
+        else:
+            logging.debug("No handler defined for %s", status)
+            return
+
+        if handler:
+            logging.debug("Calling handler for job #%s", job_id)
+            job = rq.job.Job.fetch(job_id, connection=self.conn)
+            handler(job)

--- a/arthur/scheduler.py
+++ b/arthur/scheduler.py
@@ -261,8 +261,10 @@ class Scheduler:
 
         logger.info("Task %s canceled", task_id)
 
-    def _handle_successful_job(self, job):
+    def _handle_successful_job(self, event):
         """Handle successufl jobs"""
+
+        job = rq.job.Job.fetch(event.job_id, connection=self.conn)
 
         result = job.result
         task_id = job.kwargs['task_id']
@@ -295,8 +297,10 @@ class Scheduler:
         logger.info("Job #%s (task: %s, old job: %s) re-scheduled",
                     job_id, task_id, job.id)
 
-    def _handle_failed_job(self, job):
+    def _handle_failed_job(self, event):
         """Handle failed jobs"""
+
+        job = rq.job.Job.fetch(event.job_id, connection=self.conn)
 
         task_id = job.kwargs['task_id']
         logger.error("Job #%s (task: %s) failed; cancelled",

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2019 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#
+
+import unittest
+
+from arthur.common import CH_PUBSUB
+from arthur.events import JobEventsListener
+
+from base import TestBaseRQ
+
+
+class TestJobEventsListener(TestBaseRQ):
+    """Unit tests for JobEventsListener class"""
+
+    def test_initialization(self):
+        """Test if the instance is correctly initialized"""
+
+        listener = JobEventsListener(self.conn)
+        self.assertEqual(listener.conn, self.conn)
+        self.assertEqual(listener.events_channel, CH_PUBSUB)
+        self.assertEqual(listener.result_handler, None)
+        self.assertEqual(listener.result_handler_err, None)
+
+        def handle_successful_job(job):
+            pass
+
+        def handle_failed_job(job):
+            pass
+
+        listener = JobEventsListener(self.conn,
+                                     events_channel='events',
+                                     result_handler=handle_successful_job,
+                                     result_handler_err=handle_failed_job)
+        self.assertEqual(listener.conn, self.conn)
+        self.assertEqual(listener.events_channel, 'events')
+        self.assertEqual(listener.result_handler, handle_successful_job)
+        self.assertEqual(listener.result_handler_err, handle_failed_job)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR decouples the event listener from the job scheduler. So far, the listener was tight to the scheduler and only used to reschedule tasks. With this PR it will be possible to listed to other kind of events and to have specific handlers for each events.
It's also possible to subscribe to events and to unsubscribe from them.

Once this solution is accepted, the next step will be to decouple handlers from the scheduler (now they are methods of the `Scheduler` class). To decouple it, it will be necessary to refactor some parts of the scheduler.

Fixes #50.