### PR TITLE
Started job events

### DIFF
--- a/arthur/events.py
+++ b/arthur/events.py
@@ -50,19 +50,21 @@ class JobEvent:
     a failure.
 
     Each event has a type, a unique identifier and the time when it
-    was generated (in UTC), the identifier of the job that produced
-    it and a payload. Depending on the type of event, the payload
-    might contain different data.
+    was generated (in UTC), the identifier of the job and task that
+    produced it and a payload. Depending on the type of event, the
+    payload might contain different data.
 
     :param type: event type
     :param job_id: identifier of the job
+    :param task_id: identifier of the task
     :param payload: data of the event
     """
-    def __init__(self, type, job_id, payload):
+    def __init__(self, type, job_id, task_id, payload):
         self.uuid = str(uuid.uuid4())
         self.timestamp = datetime_utcnow()
         self.type = type
         self.job_id = job_id
+        self.task_id = task_id
         self.payload = payload
 
     def serialize(self):

--- a/arthur/events.py
+++ b/arthur/events.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2014-2019 Bitergia
+# Copyright (C) 2015-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -36,8 +36,9 @@ logger = logging.getLogger(__name__)
 
 @enum.unique
 class JobEventType(enum.Enum):
-    COMPLETED = 1
-    FAILURE = 2
+    STARTED = 1
+    COMPLETED = 2
+    FAILURE = 3
     UNDEFINED = 999
 
 

--- a/arthur/scheduler.py
+++ b/arthur/scheduler.py
@@ -230,6 +230,42 @@ class _TaskScheduler(threading.Thread):
         return job_id
 
 
+class StartedJobHandler:
+    """Handle started job events.
+
+    This callable will handle the given `JobEventType.STARTED`
+    event, changing the status of the task to `TaskStatus.RUNNING`.
+
+    Take into account that while an event is received, the task
+    related to it could have been deleted but the notification
+    to cancel the job could have not reached on time. On that
+    case, the event will be considered as orphan and ignored
+    by the handler.
+
+    :param task_scheduler: TaskScheduler instance to manage tasks
+
+    :returns: `True` when the event was handled; `False` when
+        it was ignored.
+    """
+    def __init__(self, task_scheduler):
+        self.task_scheduler = task_scheduler
+
+    def __call__(self, event):
+        job_id = event.job_id
+        task_id = event.task_id
+
+        try:
+            task = self.task_scheduler.registry.get(task_id)
+        except NotFoundError:
+            logger.debug("Task %s not found; orphan event %s for job #%s ignored",
+                         task_id, event.uuid, job_id)
+            return False
+
+        task.status = TaskStatus.RUNNING
+
+        return True
+
+
 class CompletedJobHandler:
     """Handle completed job events.
 
@@ -355,6 +391,8 @@ class Scheduler:
 
         self._listener = JobEventsListener(self.conn,
                                            events_channel=pubsub_channel)
+        self._listener.subscribe(JobEventType.STARTED,
+                                 StartedJobHandler(self._scheduler))
         self._listener.subscribe(JobEventType.COMPLETED,
                                  CompletedJobHandler(self._scheduler))
         self._listener.subscribe(JobEventType.FAILURE,

--- a/arthur/scheduler.py
+++ b/arthur/scheduler.py
@@ -260,7 +260,7 @@ class CompletedJobHandler:
     def __call__(self, event):
         result = event.payload
         job_id = event.job_id
-        task_id = result.task_id
+        task_id = event.task_id
 
         try:
             task = self.task_scheduler.registry.get(task_id)
@@ -311,9 +311,9 @@ class FailedJobHandler:
         self.task_scheduler = task_scheduler
 
     def __call__(self, event):
-        result = event.payload
+        error = event.payload['error']
         job_id = event.job_id
-        task_id = result['task_id']
+        task_id = event.task_id
 
         try:
             task = self.task_scheduler.registry.get(task_id)
@@ -324,8 +324,8 @@ class FailedJobHandler:
 
         task.status = TaskStatus.FAILED
 
-        logger.error("Job #%s (task: %s) failed; cancelled",
-                     job_id, task_id)
+        logger.error("Job #%s (task: %s) failed; cancelled; error: %s",
+                     job_id, task_id, error)
 
         return True
 

--- a/arthur/worker.py
+++ b/arthur/worker.py
@@ -62,10 +62,10 @@ class ArthurWorker(rq.Worker):
     def _publish_job_event_when_started(self, job):
         """Send event notifying the job started"""
 
-        payload = {
-            'task_id': job.kwargs['task_id']
-        }
-        event = JobEvent(JobEventType.STARTED, job.id, payload)
+        task_id = job.kwargs['task_id']
+
+        event = JobEvent(JobEventType.STARTED, job.id, task_id,
+                         None)
 
         msg = event.serialize()
         self.connection.publish(self.pubsub_channel, msg)
@@ -81,7 +81,6 @@ class ArthurWorker(rq.Worker):
         elif job_status == rq.job.JobStatus.FAILED:
             event_type = JobEventType.FAILURE
             payload = {
-                'task_id': job.kwargs['task_id'],
                 'error': job.exc_info
             }
         else:
@@ -90,7 +89,9 @@ class ArthurWorker(rq.Worker):
             event_type = JobEventType.UNDEFINED
             payload = job_status
 
-        event = JobEvent(event_type, job.id, payload)
+        task_id = job.kwargs['task_id']
+
+        event = JobEvent(event_type, job.id, task_id, payload)
 
         msg = event.serialize()
         self.connection.publish(self.pubsub_channel, msg)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -108,7 +108,7 @@ class TestCompletedJobHandler(TestBaseRQ):
         task = self.registry.add('mytask', 'git', 'commit', {})
         result = JobResult(0, 'mytask', 'git', 'commit',
                            'FFFFFFFF', 1392185439.0, 9)
-        event = JobEvent(JobEventType.COMPLETED, 0, result)
+        event = JobEvent(JobEventType.COMPLETED, 0, 'mytask', result)
 
         handled = handler(event)
         self.assertEqual(handled, True)
@@ -124,7 +124,7 @@ class TestCompletedJobHandler(TestBaseRQ):
                                  archiving_cfg=archiving_cfg)
         result = JobResult(0, 'mytask', 'git', 'commit',
                            'FFFFFFFF', 1392185439.0, 9)
-        event = JobEvent(JobEventType.COMPLETED, 0, result)
+        event = JobEvent(JobEventType.COMPLETED, 0, 'mytask', result)
 
         handled = handler(event)
         self.assertEqual(handled, True)
@@ -138,7 +138,7 @@ class TestCompletedJobHandler(TestBaseRQ):
         task = self.registry.add('mytask', 'git', 'commit', {})
         result = JobResult(0, 'mytask', 'git', 'commit',
                            'FFFFFFFF', 1392185439.0, 9)
-        event = JobEvent(JobEventType.COMPLETED, 0, result)
+        event = JobEvent(JobEventType.COMPLETED, 0, 'mytask', result)
 
         handled = handler(event)
         self.assertEqual(handled, True)
@@ -158,7 +158,7 @@ class TestCompletedJobHandler(TestBaseRQ):
         result = JobResult(0, 'mytask', 'git', 'commit',
                            'FFFFFFFF', 1392185439.0, 9,
                            offset=1000)
-        event = JobEvent(JobEventType.COMPLETED, 0, result)
+        event = JobEvent(JobEventType.COMPLETED, 0, 'mytask', result)
 
         handled = handler(event)
         self.assertEqual(handled, True)
@@ -177,7 +177,7 @@ class TestCompletedJobHandler(TestBaseRQ):
 
         result = JobResult(0, 'mytask', 'git', 'commit',
                            'FFFFFFFF', 1392185439.0, 9)
-        event = JobEvent(JobEventType.COMPLETED, 0, result)
+        event = JobEvent(JobEventType.COMPLETED, 0, 'mytask', result)
 
         handled = handler(event)
         self.assertEqual(handled, False)
@@ -205,10 +205,9 @@ class TestFailedJobHandler(TestBaseRQ):
         task = self.registry.add('mytask', 'git', 'commit', {})
 
         payload = {
-            'task_id': 'mytask',
             'error': "Error"
         }
-        event = JobEvent(JobEventType.FAILURE, 0, payload)
+        event = JobEvent(JobEventType.FAILURE, 0, 'mytask', payload)
 
         handled = handler(event)
         self.assertEqual(handled, True)
@@ -220,10 +219,9 @@ class TestFailedJobHandler(TestBaseRQ):
         handler = FailedJobHandler(self.task_scheduler)
 
         payload = {
-            'task_id': 'mytask',
             'error': "Error"
         }
-        event = JobEvent(JobEventType.FAILURE, 0, payload)
+        event = JobEvent(JobEventType.FAILURE, 0, 'mytask', payload)
 
         handled = handler(event)
         self.assertEqual(handled, False)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -79,14 +79,16 @@ class TestArthurWorker(TestBaseRQ):
         msg_a = pubsub.get_message()
         event = JobEvent.deserialize(msg_a['data'])
         self.assertEqual(event.job_id, job_a.id)
+        self.assertEqual(event.task_id, 0)
         self.assertEqual(event.type, JobEventType.STARTED)
-        self.assertEqual(event.payload, {'task_id': 0})
+        self.assertEqual(event.payload, None)
 
         # COMPLETED event for job 'a'
         msg_a = pubsub.get_message()
         event = JobEvent.deserialize(msg_a['data'])
         self.assertEqual(job_a.result, 5)
         self.assertEqual(event.job_id, job_a.id)
+        self.assertEqual(event.task_id, 0)
         self.assertEqual(event.type, JobEventType.COMPLETED)
         self.assertEqual(event.payload, 5)
 
@@ -94,16 +96,17 @@ class TestArthurWorker(TestBaseRQ):
         msg_b = pubsub.get_message()
         event = JobEvent.deserialize(msg_b['data'])
         self.assertEqual(event.job_id, job_b.id)
+        self.assertEqual(event.task_id, 1)
         self.assertEqual(event.type, JobEventType.STARTED)
-        self.assertEqual(event.payload, {'task_id': 1})
+        self.assertEqual(event.payload, None)
 
         # FAILURE event for job 'b'
         msg_b = pubsub.get_message()
         event = JobEvent.deserialize(msg_b['data'])
         self.assertEqual(job_b.result, None)
         self.assertEqual(event.job_id, job_b.id)
+        self.assertEqual(event.task_id, 1)
         self.assertEqual(event.type, JobEventType.FAILURE)
-        self.assertEqual(event.payload['task_id'], 1)
         self.assertRegex(event.payload['error'], "Traceback")
 
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -38,17 +38,23 @@ class MockArthurWorker(rq.worker.SimpleWorker, ArthurWorker):
 class TestArthurWorker(TestBaseRQ):
     """Unit tests for ArthurWorker class"""
 
-    def test_publish_finished_job_status_channel_override(self):
-        self._publish_finished_job_status('test_channel')
+    def test_publish_job_events(self):
+        """Tests whether job events are correctly sent"""
 
-    def test_publish_finished_job_status_channel_default(self):
-        self._publish_finished_job_status(CH_PUBSUB, skip_pubsub_override=True)
+        self._publish_job_events(CH_PUBSUB)
 
-    def test_publish_finished_job_status(self):
-        self._publish_finished_job_status(CH_PUBSUB)
+    def test_publish_job_events_channel_default(self):
+        """Tests whether job events are correctly sent to the default channel"""
 
-    def _publish_finished_job_status(self, pubsub_channel, skip_pubsub_override=False):
-        """Test whether the worker publishes the status of a finished job"""
+        self._publish_job_events(CH_PUBSUB)
+
+    def test_publish_job_events_channel_override(self):
+        """"Tests whether job events are correctly sent in a defined channel"""
+
+        self._publish_job_events('test_channel', pubsub_override=True)
+
+    def _publish_job_events(self, pubsub_channel, pubsub_override=False):
+        """Generic job events tests"""
 
         pubsub = self.conn.pubsub()
         pubsub.subscribe(pubsub_channel)
@@ -56,32 +62,48 @@ class TestArthurWorker(TestBaseRQ):
         q = rq.Queue('foo')
         w = MockArthurWorker([q])
 
-        if not skip_pubsub_override:
+        if pubsub_override:
             w.pubsub_channel = pubsub_channel
 
         job_a = q.enqueue(mock_sum, task_id=0, a=2, b=3)
-        job_b = q.enqueue(mock_failure, task_id=0)
+        job_b = q.enqueue(mock_failure, task_id=1)
 
         status = w.work(burst=True)
         self.assertEqual(status, True)
 
-        # Ignore the first message because it is a
+        # Ignore the first messages because it is a
         # subscription notification
         _ = pubsub.get_message()
-        msg_a = pubsub.get_message()
-        msg_b = pubsub.get_message()
 
+        # STARTED event for job 'a'
+        msg_a = pubsub.get_message()
+        event = JobEvent.deserialize(msg_a['data'])
+        self.assertEqual(event.job_id, job_a.id)
+        self.assertEqual(event.type, JobEventType.STARTED)
+        self.assertEqual(event.payload, {'task_id': 0})
+
+        # COMPLETED event for job 'a'
+        msg_a = pubsub.get_message()
         event = JobEvent.deserialize(msg_a['data'])
         self.assertEqual(job_a.result, 5)
         self.assertEqual(event.job_id, job_a.id)
         self.assertEqual(event.type, JobEventType.COMPLETED)
         self.assertEqual(event.payload, 5)
 
+        # STARTED event for job 'b'
+        msg_b = pubsub.get_message()
+        event = JobEvent.deserialize(msg_b['data'])
+        self.assertEqual(event.job_id, job_b.id)
+        self.assertEqual(event.type, JobEventType.STARTED)
+        self.assertEqual(event.payload, {'task_id': 1})
+
+        # FAILURE event for job 'b'
+        msg_b = pubsub.get_message()
         event = JobEvent.deserialize(msg_b['data'])
         self.assertEqual(job_b.result, None)
         self.assertEqual(event.job_id, job_b.id)
         self.assertEqual(event.type, JobEventType.FAILURE)
-        self.assertEqual(event.payload['task_id'], 0)
+        self.assertEqual(event.payload['task_id'], 1)
         self.assertRegex(event.payload['error'], "Traceback")
 
 


### PR DESCRIPTION
This PR adds a new type of event: `JobEvent.STARTED` that is handled by the scheduler. When this event is handled, the scheduler is able to set the task that generate the job to `RUNNING`. This adds the feature requested in #60 .

To implement this feature it was also needed to include the task identifier within the `JobEvent` object. The reason to do this is all the handlers need the task identifier, so it makes sense to include it in the event instead of looking for it.