### PR TITLE
Store task jobs

### DIFF
--- a/arthur/jobs.py
+++ b/arthur/jobs.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2016 Bitergia
+# Copyright (C) 2015-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -13,8 +13,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>
@@ -91,6 +90,18 @@ class JobResult:
         self.nitems = nitems
         self.offset = offset
         self.nresumed = nresumed
+
+    def to_dict(self):
+        """Convert object to a dict"""
+
+        return {
+            'job_id': self.job_id,
+            'task_id': self.task_id,
+            'last_uuid': self.last_uuid,
+            'max_date': self.max_date,
+            'nitems': self.nitems,
+            'offset': self.offset
+        }
 
 
 class PercevalJob:

--- a/arthur/scheduler.py
+++ b/arthur/scheduler.py
@@ -183,8 +183,8 @@ class _TaskScheduler(threading.Thread):
         del self._tasks_events[task_id]
 
         task.status = TaskStatus.ENQUEUED
-        task.last_job = job_id
         task.age += 1
+        task.jobs.append(job_id)
 
         self._rwlock.writer_release()
 

--- a/arthur/scheduler.py
+++ b/arthur/scheduler.py
@@ -54,6 +54,9 @@ logger = logging.getLogger(__name__)
 # Poll scheduler after this seconds
 SCHED_POLLING = 0.5
 
+# Do not remove jobs and results from the database
+INFINITE_TTL = -1
+
 
 class _TaskScheduler(threading.Thread):
     """Private class to schedule tasks.
@@ -179,6 +182,8 @@ class _TaskScheduler(threading.Thread):
         self._queues[queue_id].enqueue(execute_perceval_job,
                                        job_id=job_id,
                                        timeout=TIMEOUT,
+                                       ttl=INFINITE_TTL,
+                                       result_ttl=INFINITE_TTL,
                                        **job_args)
         del self._tasks_events[task_id]
 

--- a/arthur/tasks.py
+++ b/arthur/tasks.py
@@ -94,6 +94,7 @@ class Task:
         self._task_id = task_id
         self.status = TaskStatus.NEW
         self.age = 0
+        self.jobs = []
         self.created_on = datetime.datetime.now().timestamp()
         self.backend = backend
         self.category = category
@@ -110,6 +111,7 @@ class Task:
             'task_id': self.task_id,
             'status': self.status.name,
             'age': self.age,
+            'jobs': self.jobs,
             'created_on': self.created_on,
             'backend': self.backend,
             'backend_args': self.backend_args,

--- a/arthur/tasks.py
+++ b/arthur/tasks.py
@@ -27,6 +27,7 @@ import re
 
 from grimoirelab_toolkit.datetime import (InvalidDateError,
                                           datetime_to_utc,
+                                          datetime_utcnow,
                                           str_to_datetime)
 from grimoirelab_toolkit.introspect import find_class_properties
 
@@ -95,7 +96,7 @@ class Task:
         self.status = TaskStatus.NEW
         self.age = 0
         self.jobs = []
-        self.created_on = datetime.datetime.now().timestamp()
+        self.created_on = datetime_utcnow().timestamp()
         self.backend = backend
         self.category = category
         self.backend_args = backend_args

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2016 Bitergia
+# Copyright (C) 2015-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -14,8 +14,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>
@@ -253,6 +252,24 @@ class TestJobResult(unittest.TestCase):
 
         self.assertEqual(result.offset, 128)
         self.assertEqual(result.nresumed, 10)
+
+    def test_to_dict(self):
+        """Test whether a JobResult object is converted to a dict"""
+
+        result = JobResult('arthur-job-1234567890', 'mytask', 'mock_backend', 'category',
+                           'ABCDEFGHIJK', 1344965413.0, 58)
+
+        expected = {
+            'job_id': 'arthur-job-1234567890',
+            'task_id': 'mytask',
+            'last_uuid': 'ABCDEFGHIJK',
+            'max_date': 1344965413.0,
+            'nitems': 58,
+            'offset': None,
+        }
+
+        d = result.to_dict()
+        self.assertEqual(d, expected)
 
 
 class TestPercevalJob(TestBaseRQ):

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -55,6 +55,8 @@ class TestTask(unittest.TestCase):
 
         self.assertEqual(task.task_id, 'mytask')
         self.assertEqual(task.status, TaskStatus.NEW)
+        self.assertEqual(task.age, 0)
+        self.assertListEqual(task.jobs, [])
         self.assertEqual(task.backend, 'mock_backend')
         self.assertEqual(task.category, 'category')
         self.assertDictEqual(task.backend_args, args)
@@ -74,6 +76,8 @@ class TestTask(unittest.TestCase):
 
         self.assertEqual(task.task_id, 'mytask')
         self.assertEqual(task.status, TaskStatus.NEW)
+        self.assertEqual(task.age, 0)
+        self.assertListEqual(task.jobs, [])
         self.assertEqual(task.backend, 'mock_backend')
         self.assertEqual(task.category, 'category')
         self.assertDictEqual(task.backend_args, args)
@@ -96,12 +100,16 @@ class TestTask(unittest.TestCase):
 
         task = Task('mytask', 'mock_backend', category, args,
                     archiving_cfg=archive, scheduling_cfg=sched)
+        task.jobs.append('job-0')
+        task.jobs.append('job-1')
+
         d = task.to_dict()
 
         expected = {
             'task_id': 'mytask',
             'status': 'NEW',
             'age': 0,
+            'jobs': ['job-0', 'job-1'],
             'backend': 'mock_backend',
             'backend_args': args,
             'category': category,
@@ -156,6 +164,7 @@ class TestTaskRegistry(unittest.TestCase):
         self.assertEqual(task.task_id, 'mytask')
         self.assertEqual(task.status, TaskStatus.NEW)
         self.assertEqual(task.age, 0)
+        self.assertListEqual(task.jobs, [])
         self.assertEqual(task.category, 'category')
         self.assertEqual(task.backend, 'mock_backend')
         self.assertDictEqual(task.backend_args, args)
@@ -175,6 +184,7 @@ class TestTaskRegistry(unittest.TestCase):
         self.assertEqual(task0.task_id, 'atask')
         self.assertEqual(task0.status, TaskStatus.NEW)
         self.assertEqual(task.age, 0)
+        self.assertListEqual(task.jobs, [])
         self.assertEqual(task0.backend, 'mock_backend')
         self.assertEqual(task0.category, 'category')
         self.assertDictEqual(task0.backend_args, args)

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -22,6 +22,7 @@
 
 import datetime
 import unittest
+import unittest.mock
 
 import dateutil
 
@@ -42,14 +43,17 @@ INVALID_FETCH_FROM_ARCHIVE_ERROR = "'fetch_from_archive' must be a bool;"
 class TestTask(unittest.TestCase):
     """Unit tests for Task"""
 
-    def test_init(self):
+    @unittest.mock.patch('arthur.tasks.datetime_utcnow')
+    def test_init(self, mock_utcnow):
         """Check arguments initialization"""
+
+        mock_utcnow.return_value = datetime.datetime(2017, 1, 1,
+                                                     tzinfo=dateutil.tz.tzutc())
 
         args = {
             'from_date': '1970-01-01',
             'component': 'test'
         }
-        before = datetime.datetime.now().timestamp()
 
         task = Task('mytask', 'mock_backend', 'category', args)
 
@@ -62,14 +66,12 @@ class TestTask(unittest.TestCase):
         self.assertDictEqual(task.backend_args, args)
         self.assertEqual(task.archiving_cfg, None)
         self.assertEqual(task.scheduling_cfg, None)
-        self.assertGreater(task.created_on, before)
+        self.assertEqual(task.created_on, 1483228800.0)
 
         # Test when archive and scheduler arguments are given
         archive = ArchivingTaskConfig('/tmp/archive', False,
                                       archived_after=None)
         sched = SchedulingTaskConfig(delay=10, max_retries=2)
-
-        before = datetime.datetime.now().timestamp()
 
         task = Task('mytask', 'mock_backend', 'category', args,
                     archiving_cfg=archive, scheduling_cfg=sched)
@@ -83,7 +85,7 @@ class TestTask(unittest.TestCase):
         self.assertDictEqual(task.backend_args, args)
         self.assertEqual(task.archiving_cfg, archive)
         self.assertEqual(task.scheduling_cfg, sched)
-        self.assertGreater(task.created_on, before)
+        self.assertEqual(task.created_on, 1483228800.0)
 
     def test_to_dict(self):
         """Check whether the object is converted into a dict"""


### PR DESCRIPTION
This PR contains some modifications to keep the history of task jobs.

First, it includes a new attribute in `Task` objects to store the list of jobs id. This list will be updated by the scheduler once the job is enqueued.

TTL of jobs and results were modified, so they won't deleted from the database. This will keep the history.

Detailed jobs history can be obtained using the REST API call `task`. Giving the task identificator, this method will return all the information related to the task and its jobs.

This PR adds the feature described in #61 .