### PR TITLE
[common] Rename queue names

### DIFF
--- a/arthur/common.py
+++ b/arthur/common.py
@@ -24,9 +24,9 @@ ARCHIVES_DEFAULT_PATH = '~/.arthur/archives/'
 
 CH_PUBSUB = 'ch_arthur'
 
-Q_ARCHIVE_JOBS = 'archive'
-Q_CREATION_JOBS = 'create'
-Q_UPDATING_JOBS = 'update'
+Q_ARCHIVE_JOBS = 'archive_jobs'
+Q_CREATION_JOBS = 'initial_fetch_jobs'
+Q_UPDATING_JOBS = 'incremental_fetch_jobs'
 Q_STORAGE_ITEMS = 'items'
 
 TIMEOUT = 3600 * 24

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -32,6 +32,7 @@ import requests
 import rq
 
 from arthur.server import ArthurServer
+from arthur.common import Q_CREATION_JOBS
 
 from base import TestBaseRQ
 
@@ -372,7 +373,7 @@ class TestArthurServer(TestBaseRQ):
             self.assertEqual(job['job_id'], job_task_result['job_id'])
             self.assertEqual(job['job_status'], 'finished')
             self.assertEqual(job['timeout'], 86400)
-            self.assertEqual(job['origin'], 'create')
+            self.assertEqual(job['origin'], Q_CREATION_JOBS)
             self.assertEqual(job['result'], job_task_result)
             self.assertEqual(job['log'], mock_logs)
 


### PR DESCRIPTION
This PR addresses: https://github.com/chaoss/grimoirelab-kingarthur/issues/87. It renames the names of Arthur queues, in the following way:
- create  --> initial_fetch_jobs
- update  --> incremental_fetch_jobs
- archive --> archive_jobs

Note that the variable names haven't changed