### PR TITLE
Fix return of the job when the job is "queued"

### DIFF
--- a/arthur/scheduler.py
+++ b/arthur/scheduler.py
@@ -182,13 +182,15 @@ class _TaskScheduler(threading.Thread):
                                               connection=self.conn,
                                               is_async=self.async_mode)
 
-        self._queues[queue_id].enqueue(execute_perceval_job,
-                                       job_id=job_id,
-                                       job_number=job_number,
-                                       job_timeout=TIMEOUT,
-                                       ttl=INFINITE_TTL,
-                                       result_ttl=INFINITE_TTL,
-                                       **job_args)
+        job_enqueued = self._queues[queue_id].enqueue(execute_perceval_job,
+                                                      job_id=job_id,
+                                                      job_number=job_number,
+                                                      job_timeout=TIMEOUT,
+                                                      ttl=INFINITE_TTL,
+                                                      result_ttl=INFINITE_TTL,
+                                                      **job_args)
+        job_enqueued.meta['job_number'] = job_number
+        job_enqueued.save_meta()
         del self._tasks_events[task_id]
 
         task.status = TaskStatus.ENQUEUED

--- a/arthur/server.py
+++ b/arthur/server.py
@@ -198,10 +198,11 @@ class ArthurServer(Arthur):
         job_result = result.to_dict() if isinstance(result, JobResult) else None
 
         job_log = job_rq.meta.get('log', None)
+        job_number = job_rq.meta.get('job_number', None)
 
         job = {
             'job_id': job_rq.id,
-            'job_number': result.job_number,
+            'job_number': job_number,
             'job_status': job_rq.get_status(),
             'job_description': job_rq.description,
             'created_at': job_rq.created_at,


### PR DESCRIPTION
In order to fix the bug described in #98, this PR adds the next functionality:

- In the scheduler, the job_number field now is saved in the metadata of the job.
- The server picks the job_number from the metadata instead of the result.