### PR TITLE
store tasks using redis

### DIFF
--- a/arthur/arthur.py
+++ b/arthur/arthur.py
@@ -49,7 +49,7 @@ class Arthur:
         rq.push_connection(self.conn)
 
         self.archive_path = base_archive_path
-        self._tasks = TaskRegistry()
+        self._tasks = TaskRegistry(self.conn)
         self._scheduler = Scheduler(self.conn, self._tasks,
                                     pubsub_channel=pubsub_channel,
                                     async_mode=async_mode)

--- a/arthur/arthur.py
+++ b/arthur/arthur.py
@@ -63,7 +63,7 @@ class Arthur:
 
         :param task_id: id of the task
         :param backend: name of the backend
-        :param category: category of the items to fecth
+        :param category: category of the items to fetch
         :param backend_args: args needed to initialize the backend
         :param archive_args: args needed to initialize the archive
         :param sched_args: scheduling args for this task
@@ -95,7 +95,7 @@ class Arthur:
         """
         try:
             self._scheduler.cancel_task(task_id)
-        except NotFoundError as e:
+        except NotFoundError:
             logger.info("Cannot cancel %s task because it does not exist.",
                         task_id)
             return False

--- a/arthur/arthur.py
+++ b/arthur/arthur.py
@@ -28,7 +28,7 @@ import pickle
 import rq
 
 from .common import CH_PUBSUB, ARCHIVES_DEFAULT_PATH, Q_STORAGE_ITEMS
-from .errors import AlreadyExistsError, NotFoundError
+from .errors import AlreadyExistsError, NotFoundError, TaskRegistryError
 from .scheduler import Scheduler
 from .tasks import ArchivingTaskConfig, SchedulingTaskConfig, TaskRegistry
 
@@ -82,6 +82,8 @@ class Arthur:
                                    archiving_cfg=archiving_cfg,
                                    scheduling_cfg=scheduling_cfg)
         except AlreadyExistsError as e:
+            raise e
+        except TaskRegistryError as e:
             raise e
 
         self._scheduler.schedule_task(task.task_id)

--- a/arthur/errors.py
+++ b/arthur/errors.py
@@ -55,3 +55,9 @@ class NotFoundError(BaseError):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.element = kwargs['element']
+
+
+class TaskRegistryError(BaseError):
+    """Generic error for TaskRegistry"""
+
+    message = "%(cause)s"

--- a/arthur/scheduler.py
+++ b/arthur/scheduler.py
@@ -119,7 +119,7 @@ class _TaskScheduler(threading.Thread):
             logger.critical(traceback.format_exc())
 
     def schedule(self):
-        """Start scheduling tasks in loop."""""
+        """Start scheduling tasks in loop."""
 
         while True:
             self._delayer.run(blocking=False)

--- a/arthur/server.py
+++ b/arthur/server.py
@@ -152,8 +152,15 @@ class ArthurServer(Arthur):
     @cherrypy.expose
     @cherrypy.tools.json_out(handler=json_encoder)
     def task(self, task_id):
-        """Get info about a task"""
+        """Get info about a task
 
+        :param task_id: id of the task
+
+        :raises NotFoundError: raised when the requested task is not
+-           found in the registry
+        :raises TaskRegistryError: raised when the requested task is not
+            retrieved from the registry
+        """
         logger.debug("API 'task' method called for task %s", task_id)
 
         task = self._tasks.get(task_id)

--- a/arthur/tasks.py
+++ b/arthur/tasks.py
@@ -219,7 +219,7 @@ class TaskRegistry:
     def remove(self, task_id):
         """Remove a task from the registry.
 
-        To remove it, pass its identifier with `taks_id` parameter.
+        To remove it, pass its identifier with `task_id` parameter.
         When the identifier is not found, a `NotFoundError` exception
         is raised.
 

--- a/arthur/tasks.py
+++ b/arthur/tasks.py
@@ -272,9 +272,6 @@ class TaskRegistry:
         :param task_id: task identifier
         :param task: task object
 
-        :raises NotFoundError: raised when the requested task is not
-            found on the registry
-
         :returns: a task object
         """
         self._rwlock.reader_acquire()
@@ -282,7 +279,7 @@ class TaskRegistry:
         self._rwlock.reader_release()
 
         if not found:
-            raise NotFoundError(element=str(task_id))
+            logger.warning("Task %s not found, adding it", str(task_id))
 
         self._rwlock.writer_acquire()
         self.conn.set(task_id, pickle.dumps(task))

--- a/arthur/tasks.py
+++ b/arthur/tasks.py
@@ -254,6 +254,32 @@ class TaskRegistry:
 
         return task
 
+    def update(self, task_id, task):
+        """Update a task in the registry.
+
+        Update a task stored in the registry using its task identifier. When
+        the task does not exist, a `NotFoundError` exception will be
+        raised.
+
+        :param task_id: task identifier
+        :param task: task object
+
+        :returns: a task object
+
+        :raises NotFoundError: raised when the requested task is not
+            found on the registry
+        """
+        self._rwlock.reader_acquire()
+
+        if task_id not in [k.decode("utf-8") for k in self.conn.keys()]:
+            self._rwlock.reader_release()
+            raise NotFoundError(element=str(task_id))
+
+        self.conn.set(task_id, pickle.dumps(task))
+        self._rwlock.reader_release()
+
+        logger.debug("Task %s updated", str(task_id))
+
     @property
     def tasks(self):
         """Get the list of tasks"""

--- a/bin/arthurd
+++ b/bin/arthurd
@@ -140,7 +140,7 @@ def read_config_file(filepath):
 
     :returns: a configuration parameters dictionary
     """
-    config = configparser.SafeConfigParser()
+    config = configparser.ConfigParser()
     config.read(filepath)
 
     args = {}
@@ -249,7 +249,7 @@ def configure_logging(log_path, debug=False, run_daemon=True):
 
     :param log_path: path where logs will be stored
     :param debug: set the debug mode
-    :param run_daemon: run Arthun in daemon mode
+    :param run_daemon: run Arthur in daemon mode
     """
     cherrypy.config.update({'log.screen': False})
 
@@ -285,7 +285,7 @@ def connect_to_redis(db_url):
     """Create a connection with a Redis database"""
 
     conn = redis.StrictRedis.from_url(db_url)
-    logging.debug("Redis connection stablished with %s.", db_url)
+    logging.debug("Redis connection established with %s.", db_url)
 
     return conn
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -36,7 +36,7 @@ class MockErrorArgs(errors.BaseError):
 
 class TestBaseError(unittest.TestCase):
 
-    def test_subblass_with_no_args(self):
+    def test_subclass_with_no_args(self):
         """Check subclasses that do not require arguments.
 
         Arguments passed to the constructor should be ignored.

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -92,5 +92,14 @@ class TestNotFoundError(unittest.TestCase):
         self.assertEqual(e.element, 'repository')
 
 
+class TestTaskRegistryError(unittest.TestCase):
+
+    def test_message(self):
+        """Make sure that prints the correct error"""
+
+        e = errors.TaskRegistryError(cause='error on registry')
+        self.assertEqual('error on registry', str(e))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -97,7 +97,7 @@ def setup_mock_bugzilla_server():
 
         http_requests.append(httpretty.last_request())
 
-        return (200, headers, body)
+        return 200, headers, body
 
     httpretty.register_uri(httpretty.GET,
                            BUGZILLA_BUGLIST_URL,
@@ -150,13 +150,13 @@ def setup_mock_redmine_server(max_failures=0):
             updated_on = params['updated_on'][0]
             offset = params['offset'][0]
 
-            if (updated_on == '>=1970-01-01T00:00:00Z' and offset == '0'):
+            if updated_on == '>=1970-01-01T00:00:00Z' and offset == '0':
                 body = issues_body
-            elif (updated_on == '>=1970-01-01T00:00:00Z' and offset == '3'):
+            elif updated_on == '>=1970-01-01T00:00:00Z' and offset == '3':
                 body = issues_next_body
-            elif (updated_on == '>=2016-07-27T00:00:00Z' and offset == '0'):
+            elif updated_on == '>=2016-07-27T00:00:00Z' and offset == '0':
                 body = issues_next_body
-            elif (updated_on == '>=2011-12-08T17:58:37Z' and offset == '0'):
+            elif updated_on == '>=2011-12-08T17:58:37Z' and offset == '0':
                 body = issues_next_body
             else:
                 body = issues_empty_body
@@ -186,7 +186,7 @@ def setup_mock_redmine_server(max_failures=0):
 
         http_requests.append(last_request)
 
-        return (status, headers, body)
+        return status, headers, body
 
     for url in REDMINE_URL_LIST:
         httpretty.register_uri(httpretty.GET,

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -60,18 +60,21 @@ class TestScheduler(TestBaseRQ):
         archiving_opts = None
         scheduler_opts = SchedulingTaskConfig(delay=0, max_retries=0)
 
-        registry = TaskRegistry()
+        registry = TaskRegistry(self.conn)
         task = registry.add('mytask', 'git', category, args,
                             archiving_cfg=archiving_opts,
                             scheduling_cfg=scheduler_opts)
 
         schlr = Scheduler(self.conn, registry, async_mode=False)
         schlr.schedule_task(task.task_id)
+
+        task = registry.get('mytask')
         self.assertEqual(task.status, TaskStatus.SCHEDULED)
         self.assertEqual(task.age, 0)
 
         schlr.schedule()
 
+        task = registry.get('mytask')
         self.assertEqual(task.age, 1)
 
         job = schlr._scheduler._queues[Q_CREATION_JOBS].fetch_job(task.jobs[0].id)
@@ -96,18 +99,21 @@ class TestScheduler(TestBaseRQ):
         scheduler_opts = SchedulingTaskConfig(delay=0, max_retries=0,
                                               queue='myqueue')
 
-        registry = TaskRegistry()
+        registry = TaskRegistry(self.conn)
         task = registry.add('mytask', 'git', category, args,
                             archiving_cfg=archiving_opts,
                             scheduling_cfg=scheduler_opts)
 
         schlr = Scheduler(self.conn, registry, async_mode=False)
         schlr.schedule_task(task.task_id)
+
+        task = registry.get('mytask')
         self.assertEqual(task.status, TaskStatus.SCHEDULED)
         self.assertEqual(task.age, 0)
 
         schlr.schedule()
 
+        task = registry.get('mytask')
         self.assertEqual(task.age, 1)
 
         job = schlr._scheduler._queues['myqueue'].fetch_job(task.jobs[0].id)
@@ -169,13 +175,15 @@ class TestScheduler(TestBaseRQ):
         scheduler_opts = SchedulingTaskConfig(delay=0, max_retries=0,
                                               queue='myqueue')
 
-        registry = TaskRegistry()
+        registry = TaskRegistry(self.conn)
         task = registry.add('mytask', 'git', category, args,
                             archiving_cfg=archiving_opts,
                             scheduling_cfg=scheduler_opts)
 
         schlr = Scheduler(self.conn, registry, async_mode=False)
         schlr.schedule_task(task.task_id)
+
+        task = registry.get('mytask')
         self.assertEqual(task.status, TaskStatus.SCHEDULED)
         self.assertEqual(task.age, 0)
 
@@ -183,14 +191,18 @@ class TestScheduler(TestBaseRQ):
         # time running this task. Job number will be calculated
         # adding one to the length of jobs.
         task.jobs = ['A', 'B', 'C']
+        registry.update('mytask', task)
 
         schlr = Scheduler(self.conn, registry, async_mode=False)
         schlr.schedule_task(task.task_id)
+
+        task = registry.get('mytask')
         self.assertEqual(task.status, TaskStatus.SCHEDULED)
         self.assertEqual(task.age, 0)
 
         schlr.schedule()
 
+        task = registry.get('mytask')
         self.assertEqual(task.age, 1)
 
         # Get the last job run and check the result
@@ -203,7 +215,7 @@ class TestScheduler(TestBaseRQ):
     def test_not_found_task(self):
         """Raises an error when the task to schedule does not exist"""
 
-        registry = TaskRegistry()
+        registry = TaskRegistry(self.conn)
 
         schlr = Scheduler(self.conn, registry, async_mode=False)
         self.assertRaises(NotFoundError, schlr.schedule_task, 'mytask')
@@ -219,19 +231,22 @@ class TestScheduler(TestBaseRQ):
         archiving_opts = None
         scheduler_opts = SchedulingTaskConfig(delay=0, max_retries=0)
 
-        registry = TaskRegistry()
+        registry = TaskRegistry(self.conn)
         task = registry.add('mytask', 'git', category, args,
                             archiving_cfg=archiving_opts,
                             scheduling_cfg=scheduler_opts)
 
         schlr = Scheduler(self.conn, registry, async_mode=False)
         schlr.schedule_task(task.task_id)
+
+        task = registry.get('mytask')
         self.assertEqual(task.status, TaskStatus.SCHEDULED)
         self.assertEqual(task.age, 0)
         self.assertListEqual(task.jobs, [])
 
         schlr.schedule()
 
+        task = registry.get('mytask')
         self.assertEqual(task.age, 1)
         self.assertEqual(len(task.jobs), 1)
 
@@ -241,7 +256,7 @@ class TestStartedJobHandler(TestBaseRQ):
 
     def setUp(self):
         super().setUp()
-        self.registry = TaskRegistry()
+        self.registry = TaskRegistry(self.conn)
         self.task_scheduler = _TaskScheduler(self.registry, self.conn, [])
 
     def test_initialization(self):
@@ -255,12 +270,14 @@ class TestStartedJobHandler(TestBaseRQ):
 
         handler = StartedJobHandler(self.task_scheduler)
 
-        task = self.registry.add('mytask', 'git', 'commit', {})
+        _ = self.registry.add('mytask', 'git', 'commit', {})
 
         event = JobEvent(JobEventType.STARTED, 0, 'mytask', None)
 
         handled = handler(event)
         self.assertEqual(handled, True)
+
+        task = self.registry.get('mytask')
         self.assertEqual(task.status, TaskStatus.RUNNING)
 
     def test_ignore_orphan_event(self):
@@ -279,7 +296,7 @@ class TestCompletedJobHandler(TestBaseRQ):
 
     def setUp(self):
         super().setUp()
-        self.registry = TaskRegistry()
+        self.registry = TaskRegistry(self.conn)
         self.task_scheduler = _TaskScheduler(self.registry, self.conn, [])
 
     def test_initialization(self):
@@ -293,7 +310,7 @@ class TestCompletedJobHandler(TestBaseRQ):
 
         handler = CompletedJobHandler(self.task_scheduler)
 
-        task = self.registry.add('mytask', 'git', 'commit', {})
+        _ = self.registry.add('mytask', 'git', 'commit', {})
 
         result = JobResult(0, 1, 'mytask', 'git', 'commit')
 
@@ -307,6 +324,8 @@ class TestCompletedJobHandler(TestBaseRQ):
 
         handled = handler(event)
         self.assertEqual(handled, True)
+
+        task = self.registry.get('mytask')
         self.assertEqual(task.status, TaskStatus.SCHEDULED)
 
     def test_task_rescheduling_age(self):
@@ -332,6 +351,8 @@ class TestCompletedJobHandler(TestBaseRQ):
 
         handled = handler(event)
         self.assertEqual(handled, True)
+
+        task = self.registry.get('mytask')
         self.assertEqual(task.status, TaskStatus.SCHEDULED)
 
     def test_task_rescheduling_unlimited_age(self):
@@ -357,6 +378,8 @@ class TestCompletedJobHandler(TestBaseRQ):
 
         handled = handler(event)
         self.assertEqual(handled, True)
+
+        task = self.registry.get('mytask')
         self.assertEqual(task.status, TaskStatus.SCHEDULED)
 
     def test_task_not_rescheduled_age_limit(self):
@@ -365,10 +388,11 @@ class TestCompletedJobHandler(TestBaseRQ):
         handler = CompletedJobHandler(self.task_scheduler)
 
         scheduler_opts = SchedulingTaskConfig(delay=0, max_retries=0, max_age=3)
-        task = self.registry.add('mytask', 'git', 'commit', {},
-                                 scheduling_cfg=scheduler_opts)
+        task = self.task_scheduler.registry.add('mytask', 'git', 'commit', {},
+                                                scheduling_cfg=scheduler_opts)
         # Force the age to its pre-defined limit
         task.age = 3
+        self.task_scheduler.registry.update('mytask', task)
 
         result = JobResult(0, 1, 'mytask', 'git', 'commit')
 
@@ -382,6 +406,8 @@ class TestCompletedJobHandler(TestBaseRQ):
 
         handled = handler(event)
         self.assertEqual(handled, True)
+
+        task = self.task_scheduler.registry.get('mytask')
         self.assertEqual(task.status, TaskStatus.COMPLETED)
 
     def test_task_not_rescheduled_archive_task(self):
@@ -390,8 +416,7 @@ class TestCompletedJobHandler(TestBaseRQ):
         handler = CompletedJobHandler(self.task_scheduler)
 
         archiving_cfg = ArchivingTaskConfig('/tmp/archive', True)
-        task = self.registry.add('mytask', 'git', 'commit', {},
-                                 archiving_cfg=archiving_cfg)
+        _ = self.task_scheduler.registry.add('mytask', 'git', 'commit', {}, archiving_cfg=archiving_cfg)
 
         result = JobResult(0, 1, 'mytask', 'git', 'commit')
 
@@ -405,6 +430,8 @@ class TestCompletedJobHandler(TestBaseRQ):
 
         handled = handler(event)
         self.assertEqual(handled, True)
+
+        task = self.task_scheduler.registry.get('mytask')
         self.assertEqual(task.status, TaskStatus.COMPLETED)
 
     def test_task_rescheduled_with_next_from_date(self):
@@ -412,7 +439,7 @@ class TestCompletedJobHandler(TestBaseRQ):
 
         handler = CompletedJobHandler(self.task_scheduler)
 
-        task = self.registry.add('mytask', 'git', 'commit', {})
+        _ = self.task_scheduler.registry.add('mytask', 'git', 'commit', {})
         result = JobResult(0, 1, 'mytask', 'git', 'commit')
 
         summary = Summary()
@@ -425,6 +452,8 @@ class TestCompletedJobHandler(TestBaseRQ):
 
         handled = handler(event)
         self.assertEqual(handled, True)
+
+        task = self.task_scheduler.registry.get('mytask')
         self.assertEqual(task.status, TaskStatus.SCHEDULED)
 
         # The field is updated to the max date received
@@ -437,7 +466,7 @@ class TestCompletedJobHandler(TestBaseRQ):
 
         handler = CompletedJobHandler(self.task_scheduler)
 
-        task = self.registry.add('mytask', 'git', 'commit', {})
+        _ = self.task_scheduler.registry.add('mytask', 'git', 'commit', {})
         result = JobResult(0, 1, 'mytask', 'git', 'commit')
 
         summary = Summary()
@@ -452,6 +481,8 @@ class TestCompletedJobHandler(TestBaseRQ):
 
         handled = handler(event)
         self.assertEqual(handled, True)
+
+        task = self.task_scheduler.registry.get('mytask')
         self.assertEqual(task.status, TaskStatus.SCHEDULED)
 
         # Both fields are updated to the max value received
@@ -465,7 +496,7 @@ class TestCompletedJobHandler(TestBaseRQ):
 
         handler = CompletedJobHandler(self.task_scheduler)
 
-        task = self.registry.add('mytask', 'git', 'commit', {})
+        _ = self.task_scheduler.registry.add('mytask', 'git', 'commit', {})
         result = JobResult(0, 1, 'mytask', 'git', 'commit')
 
         summary = Summary()
@@ -478,6 +509,8 @@ class TestCompletedJobHandler(TestBaseRQ):
 
         handled = handler(event)
         self.assertEqual(handled, True)
+
+        task = self.task_scheduler.registry.get('mytask')
         self.assertEqual(task.status, TaskStatus.SCHEDULED)
 
         # Both fields are not updated
@@ -489,7 +522,7 @@ class TestCompletedJobHandler(TestBaseRQ):
 
         handler = CompletedJobHandler(self.task_scheduler)
 
-        task = self.registry.add('mytask', 'git', 'commit', {})
+        task = self.task_scheduler.registry.add('mytask', 'git', 'commit', {})
 
         # Force to a pre-defined number of failures
         task.num_failures = 2
@@ -506,6 +539,8 @@ class TestCompletedJobHandler(TestBaseRQ):
 
         handled = handler(event)
         self.assertEqual(handled, True)
+
+        task = self.task_scheduler.registry.get('mytask')
         self.assertEqual(task.status, TaskStatus.SCHEDULED)
         self.assertEqual(task.num_failures, 0)
 
@@ -526,7 +561,7 @@ class TestFailedJobHandler(TestBaseRQ):
 
     def setUp(self):
         super().setUp()
-        self.registry = TaskRegistry()
+        self.registry = TaskRegistry(self.conn)
         self.task_scheduler = _TaskScheduler(self.registry, self.conn, [])
 
     def test_initialization(self):
@@ -540,7 +575,7 @@ class TestFailedJobHandler(TestBaseRQ):
 
         handler = FailedJobHandler(self.task_scheduler)
 
-        task = self.registry.add('mytask', 'git', 'commit', {})
+        _ = self.registry.add('mytask', 'git', 'commit', {})
 
         result = JobResult(0, 1, 'mytask', 'git', 'commit')
 
@@ -559,6 +594,8 @@ class TestFailedJobHandler(TestBaseRQ):
         # It won't be scheduled because max_retries is not set
         handled = handler(event)
         self.assertEqual(handled, True)
+
+        task = self.registry.get('mytask')
         self.assertEqual(task.status, TaskStatus.FAILED)
 
     def test_task_not_rescheduled_not_resume(self):
@@ -586,6 +623,8 @@ class TestFailedJobHandler(TestBaseRQ):
 
         handled = handler(event)
         self.assertEqual(handled, True)
+
+        task = self.registry.get('mytask')
         self.assertEqual(task.status, TaskStatus.FAILED)
         self.assertEqual(task.num_failures, 1)
 
@@ -595,11 +634,11 @@ class TestFailedJobHandler(TestBaseRQ):
         handler = FailedJobHandler(self.task_scheduler)
 
         scheduler_opts = SchedulingTaskConfig(delay=0, max_retries=3)
-        task = self.registry.add('mytask', 'git', 'commit', {},
-                                 scheduling_cfg=scheduler_opts)
+        task = self.task_scheduler.registry.add('mytask', 'git', 'commit', {}, scheduling_cfg=scheduler_opts)
 
         # Force to a pre-defined number of failures
         task.num_failures = 2
+        self.task_scheduler.registry.update('mytask', task)
 
         result = JobResult(0, 1, 'mytask', 'git', 'commit')
 
@@ -617,6 +656,8 @@ class TestFailedJobHandler(TestBaseRQ):
 
         handled = handler(event)
         self.assertEqual(handled, True)
+
+        task = self.task_scheduler.registry.get('mytask')
         self.assertEqual(task.status, TaskStatus.FAILED)
         self.assertEqual(task.num_failures, 3)
 
@@ -626,8 +667,7 @@ class TestFailedJobHandler(TestBaseRQ):
         handler = FailedJobHandler(self.task_scheduler)
 
         scheduler_opts = SchedulingTaskConfig(delay=0, max_retries=3)
-        task = self.registry.add('mytask', 'git', 'commit', {},
-                                 scheduling_cfg=scheduler_opts)
+        _ = self.task_scheduler.registry.add('mytask', 'git', 'commit', {}, scheduling_cfg=scheduler_opts)
 
         result = JobResult(0, 1, 'mytask', 'git', 'commit')
 
@@ -645,6 +685,8 @@ class TestFailedJobHandler(TestBaseRQ):
 
         handled = handler(event)
         self.assertEqual(handled, True)
+
+        task = self.task_scheduler.registry.get('mytask')
         self.assertEqual(task.status, TaskStatus.SCHEDULED)
 
         # The field is updated to the max date received
@@ -659,8 +701,7 @@ class TestFailedJobHandler(TestBaseRQ):
         handler = FailedJobHandler(self.task_scheduler)
 
         scheduler_opts = SchedulingTaskConfig(delay=0, max_retries=3)
-        task = self.registry.add('mytask', 'git', 'commit', {},
-                                 scheduling_cfg=scheduler_opts)
+        _ = self.registry.add('mytask', 'git', 'commit', {}, scheduling_cfg=scheduler_opts)
 
         result = JobResult(0, 1, 'mytask', 'git', 'commit')
 
@@ -680,6 +721,8 @@ class TestFailedJobHandler(TestBaseRQ):
 
         handled = handler(event)
         self.assertEqual(handled, True)
+
+        task = self.registry.get('mytask')
         self.assertEqual(task.status, TaskStatus.SCHEDULED)
 
         # Both fields are updated to the max value received
@@ -695,8 +738,7 @@ class TestFailedJobHandler(TestBaseRQ):
         handler = FailedJobHandler(self.task_scheduler)
 
         scheduler_opts = SchedulingTaskConfig(delay=0, max_retries=3)
-        task = self.registry.add('mytask', 'git', 'commit', {},
-                                 scheduling_cfg=scheduler_opts)
+        _ = self.task_scheduler.registry.add('mytask', 'git', 'commit', {}, scheduling_cfg=scheduler_opts)
 
         result = JobResult(0, 1, 'mytask', 'git', 'commit')
 
@@ -714,6 +756,8 @@ class TestFailedJobHandler(TestBaseRQ):
 
         handled = handler(event)
         self.assertEqual(handled, True)
+
+        task = self.task_scheduler.registry.get('mytask')
         self.assertEqual(task.status, TaskStatus.SCHEDULED)
 
         # Both fields are not updated

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -299,7 +299,7 @@ class TestTaskRegistry(TestBaseRQ):
         self.assertGreater(task0.created_on, task1.created_on)
 
     def test_add_existing_task(self):
-        """Check if it raises an exception when an exisiting task is added again"""
+        """Check if it raises an exception when an existing task is added again"""
 
         registry = TaskRegistry(self.conn)
         registry.add('mytask', 'git', 'commit', {})

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -33,7 +33,8 @@ from arthur.tasks import (ArchivingTaskConfig,
                           Task,
                           JobData,
                           TaskRegistry,
-                          TaskStatus)
+                          TaskStatus,
+                          logger)
 
 from base import TestBaseRQ
 
@@ -420,8 +421,9 @@ class TestTaskRegistry(TestBaseRQ):
 
         registry = TaskRegistry(self.conn)
 
-        with self.assertRaises(NotFoundError):
+        with self.assertLogs(logger, level='WARNING') as cm:
             registry.update('mytask', None)
+            self.assertEqual(cm.output[0], 'WARNING:arthur.tasks:Task mytask not found, adding it')
 
 
 class TestArchivingTaskConfig(unittest.TestCase):

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -202,6 +202,22 @@ class TestTaskRegistry(TestBaseRQ):
 
         self.assertListEqual(tasks, [])
 
+    def test_tasks(self):
+        """Test to list tasks in the registry"""
+
+        registry = TaskRegistry(self.conn)
+        expected = []
+        for i in range(0, 20):
+            task_id = 'mytask{}'.format(i)
+            expected.append(task_id)
+            registry.add(task_id, 'git', 'commit', {})
+
+        tasks = registry.tasks
+        self.assertEqual(len(tasks), 20)
+
+        for t in tasks:
+            self.assertIn(t.task_id, expected)
+
     def test_add_task(self):
         """Test to add tasks to the registry"""
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -219,6 +219,27 @@ class TestTaskRegistry(TestBaseRQ):
         for t in tasks:
             self.assertIn(t.task_id, expected)
 
+    def test_matched_tasks(self):
+        """Test to list tasks in the registry when other data is stored in Redis"""
+
+        registry = TaskRegistry(self.conn)
+
+        self.conn.set("key1", 'value')
+        self.conn.set("key2", 1)
+        self.conn.set("key3", b'x')
+
+        expected = []
+        for i in range(0, 20):
+            task_id = 'mytask{}'.format(i)
+            expected.append(task_id)
+            registry.add(task_id, 'git', 'commit', {})
+
+        tasks = registry.tasks
+        self.assertEqual(len(tasks), 20)
+
+        for t in tasks:
+            self.assertIn(t.task_id, expected)
+
     def test_add_task(self):
         """Test to add tasks to the registry"""
 


### PR DESCRIPTION
This PR addresses https://github.com/chaoss/grimoirelab-kingarthur/issues/88. In a nutshell, tasks are now saved in redis. This implies some changes in the scheduler, arthur and task registry.

New tests have been provided, old ones have been updated accordingly.