### PR TITLE
Add job_number to the tasks and task queries

### DIFF
--- a/arthur/scheduler.py
+++ b/arthur/scheduler.py
@@ -195,7 +195,7 @@ class _TaskScheduler(threading.Thread):
 
         task.status = TaskStatus.ENQUEUED
         task.age += 1
-        task.jobs.append(job_id)
+        task.set_job(job_id, job_number)
 
         self._rwlock.writer_release()
 

--- a/arthur/server.py
+++ b/arthur/server.py
@@ -160,8 +160,8 @@ class ArthurServer(Arthur):
 
         jobs = []
 
-        for job_id in task.jobs:
-            job_rq = rq.job.Job.fetch(job_id, connection=self.conn)
+        for job in task.jobs:
+            job_rq = rq.job.Job.fetch(job.id, connection=self.conn)
             result = job_rq.result
 
             if isinstance(result, JobResult):
@@ -172,6 +172,7 @@ class ArthurServer(Arthur):
             job = {
                 'task_id': task_id,
                 'job_id': job_rq.id,
+                'job_number': job.number,
                 'job_status': job_rq.get_status(),
                 'result': job_result
             }

--- a/arthur/tasks.py
+++ b/arthur/tasks.py
@@ -20,6 +20,7 @@
 #     Alvaro del Castillo San Felix <acs@bitergia.com>
 #
 
+import collections
 import datetime
 import enum
 import logging
@@ -124,13 +125,22 @@ class Task:
 
         return self._has_resuming
 
+    def set_job(self, job_id, job_number):
+        """Adds a JobData tuple object to the job list of a task"""
+
+        job_tuple = JobData(job_id, job_number)
+        self.jobs.append(job_tuple)
+
     def to_dict(self):
         return {
             'task_id': self.task_id,
             'status': self.status.name,
             'age': self.age,
             'num_failures': self.num_failures,
-            'jobs': self.jobs,
+            'jobs': [{
+                'job_id': job.id,
+                'job_number': job.number
+            } for job in self.jobs],
             'created_on': self.created_on,
             'backend': self.backend,
             'backend_args': self.backend_args,
@@ -138,6 +148,9 @@ class Task:
             'archiving_cfg': self.archiving_cfg.to_dict() if self.archiving_cfg else None,
             'scheduling_cfg': self.scheduling_cfg.to_dict() if self.scheduling_cfg else None
         }
+
+
+JobData = collections.namedtuple('JobData', ['id', 'number'])
 
 
 class TaskRegistry:

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -73,7 +73,7 @@ class TestScheduler(TestBaseRQ):
 
         self.assertEqual(task.age, 1)
 
-        job = schlr._scheduler._queues[Q_CREATION_JOBS].fetch_job(task.jobs[0])
+        job = schlr._scheduler._queues[Q_CREATION_JOBS].fetch_job(task.jobs[0].id)
         result = job.return_value
 
         self.assertEqual(result.task_id, task.task_id)
@@ -109,7 +109,7 @@ class TestScheduler(TestBaseRQ):
 
         self.assertEqual(task.age, 1)
 
-        job = schlr._scheduler._queues['myqueue'].fetch_job(task.jobs[0])
+        job = schlr._scheduler._queues['myqueue'].fetch_job(task.jobs[0].id)
         result = job.return_value
 
         self.assertEqual(result.task_id, task.task_id)
@@ -156,7 +156,7 @@ class TestScheduler(TestBaseRQ):
         self.assertEqual(task.age, 1)
 
         # Get the last job run and check the result
-        job = schlr._scheduler._queues['myqueue'].fetch_job(task.jobs[3])
+        job = schlr._scheduler._queues['myqueue'].fetch_job(task.jobs[3].id)
         result = job.return_value
 
         self.assertEqual(result.task_id, task.task_id)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -271,6 +271,7 @@ class TestArthurServer(TestBaseRQ):
             # Check jobs data
             job = jobs[0]
             self.assertEqual(job['task_id'], 'arthur.git')
+            self.assertEqual(job['job_number'], 1)
             self.assertEqual(job['job_status'], 'finished')
 
             # TODO: mock job ids generator


### PR DESCRIPTION
Summarizing, the changes was to change the list of job_id strings that were included in the task object for a list of objects that each object includes the job_id field and the job_number (changes made in the scheduler).

Moreover, in the server, it has been needed a change in the task query, adding the field job_number field in the list of jobs that it returned.


Related to #104 