### PR TITLE
[scheduler] Reschedule failed tasks into the retry queue

### DIFF
--- a/arthur/common.py
+++ b/arthur/common.py
@@ -18,6 +18,7 @@
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>
 #     Alvaro del Castillo San Felix <acs@bitergia.com>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
 #
 
 ARCHIVES_DEFAULT_PATH = '~/.arthur/archives/'
@@ -26,6 +27,7 @@ CH_PUBSUB = 'ch_arthur'
 
 Q_ARCHIVE_JOBS = 'archive'
 Q_CREATION_JOBS = 'create'
+Q_RETRYING_JOBS = 'retry'
 Q_UPDATING_JOBS = 'update'
 Q_STORAGE_ITEMS = 'items'
 

--- a/bin/arthurw
+++ b/bin/arthurw
@@ -18,6 +18,7 @@
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
 #
 
 import argparse
@@ -30,6 +31,7 @@ import rq.utils
 
 from arthur.common import (Q_ARCHIVE_JOBS,
                            Q_CREATION_JOBS,
+                           Q_RETRYING_JOBS,
                            Q_UPDATING_JOBS,
                            CH_PUBSUB)
 from arthur.worker import ArthurWorker
@@ -66,7 +68,7 @@ def main():
 
     conn = connect_to_redis(args.database)
 
-    queues = args.queues or [Q_ARCHIVE_JOBS, Q_CREATION_JOBS, Q_UPDATING_JOBS]
+    queues = args.queues or [Q_ARCHIVE_JOBS, Q_CREATION_JOBS, Q_RETRYING_JOBS, Q_UPDATING_JOBS]
     burst = args.burst
 
     configure_logging(args.debug)


### PR DESCRIPTION
Now, all failed tasks are sent to a new queue named `retry`.

Before this change, when a task failed inside the `create` queue it was re-scheduled into `update` queue.

This PR aims to solve issue https://github.com/chaoss/grimoirelab-kingarthur/issues/93.