### PR TITLE
[travis] Support for python 3.6, 3.7 and 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,15 @@
 language: python
 
 python:
-  - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
 
 sudo: false
 
 before_install:
-  - pip install --upgrade setuptools
-  - pip install --upgrade pip
+  - pip install --upgrade setuptools==49.6.0
+  - pip install --upgrade pip==18.1
   - pip install -r "requirements.txt"
   - pip install -r "requirements_tests.txt"
   - pip install flake8


### PR DESCRIPTION
This code aims at aligning the CI tests across the different grimoirelab components.

Python 3.5 is removed as its support period has ended and Python 3.6, 3.7, and 3.8 are now supported.

The version of setuptools and pip has been downgraded as a hotfix to solve the failing CI tests.