### PR TITLE
[setup.py] No commas in entry_points

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ setup(name="kingarthur",
       test_suite='tests',
       entry_points={
           'console_scripts': [
-              'arthurd=arthur.bin.arthurd:main'
+              'arthurd=arthur.bin.arthurd:main',
               'arthurw=arthur.bin.arthurw:main'
           ]
       },


### PR DESCRIPTION
This PR adds a missing comma in entry_points command list.
